### PR TITLE
Well enhanced Art Profiles Smart Contract with read-only functions to retrieve artist profile details (art style, exhibitions, and portfolio links) 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+
+{
+    "deno.enable": true,
+    "files.eol": "\n"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "check contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet check"
+        },
+        {
+            "label": "test contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet test"
+        }
+    ]
+}

--- a/contracts/art_profiles.clar
+++ b/contracts/art_profiles.clar
@@ -104,3 +104,39 @@
         )
     )
 )
+
+;; Read-only function: Retrieve an artist's full profile
+;; Allows anyone to retrieve the complete profile of a specified artist.
+(define-read-only (get-profile (user principal))
+    (match (map-get? profiles user)
+        profile (ok profile)
+        ERR-NOT-FOUND
+    )
+)
+
+;; Read-only function: Retrieve the art style of a specific artist
+;; Provides the art style of the given artist.
+(define-read-only (get-art-style (user principal))
+    (match (map-get? profiles user)
+        profile (ok (get art_style profile))
+        ERR-NOT-FOUND
+    )
+)
+
+;; Read-only function: Retrieve the exhibitions of a specific artist
+;; Returns the list of exhibitions an artist has participated in.
+(define-read-only (get-exhibitions (user principal))
+    (match (map-get? profiles user)
+        profile (ok (get exhibitions profile))
+        ERR-NOT-FOUND
+    )
+)
+
+;; Read-only function: Retrieve the portfolio links of a specific artist
+;; Returns the portfolio links of the given artist.
+(define-read-only (get-portfolio-links (user principal))
+    (match (map-get? profiles user)
+        profile (ok (get portfolio_links profile))
+        ERR-NOT-FOUND
+    )
+)


### PR DESCRIPTION
### Summary:
This update introduces additional read-only functions to the Art Profiles Smart Contract, enabling users to access specific details of an artist's profile. These functions allow retrieval of:
- Art style
- Exhibitions the artist has participated in
- Portfolio links of the artist

### Key Changes:
- **get-profile**: Allows retrieval of a full artist profile.
- **get-art-style**: Provides the art style of a specified artist.
- **get-exhibitions**: Returns the list of exhibitions an artist has participated in.
- **get-portfolio-links**: Returns the portfolio links associated with the artist.

These functions improve the contract by making key artist data publicly accessible, while maintaining security and validation for profile updates.

Overview of Changes Compared to the Initial Contract:

- * New Read-only Functions: Added four read-only functions: get-profile, get-art-style, get-exhibitions, and get-portfolio-links to allow retrieval of specific profile information.
- * Profile Data Access:These new functions enable users to access details about an artist's profile, such as their art style, exhibitions, and portfolio links, without modifying the profile.
- * Profile Retrieval Enhancements:The initial contract only allowed for profile registration and updates. Now, users can easily view profile data without needing to update it, enhancing the usability of the platform.